### PR TITLE
fixing missing return statement on -= operator

### DIFF
--- a/ConsoleTable.cpp
+++ b/ConsoleTable.cpp
@@ -72,6 +72,7 @@ ConsoleTable &ConsoleTable::operator-=(const uint32_t rowIndex) {
         throw std::out_of_range{"Row index out of range."};
 
     removeRow(rowIndex);
+    return *this;
 }
 
 


### PR DESCRIPTION
This addresses issue #2. It also addresses warning at compilation with `clang` compiler:

```
ConsoleTable.cpp:75:1: warning: control may reach end of non-void function [-Wreturn-type]
}
^
1 warning generated.
```

Please consider for merging.